### PR TITLE
adding missing argument 'devicePixelRatio' to FixedScrollMetrics decl…

### DIFF
--- a/lib/src/floating_search_bar_scroll_notifier.dart
+++ b/lib/src/floating_search_bar_scroll_notifier.dart
@@ -36,6 +36,7 @@ class FloatingSearchBarScrollNotifier extends StatelessWidget {
           // finishes.
           if (metrics.pixels < 0 || metrics.pixels > metrics.maxScrollExtent) {
             metrics = FixedScrollMetrics(
+              devicePixelRatio: 1,
               pixels: metrics.pixels < 0 ? 0 : metrics.maxScrollExtent,
               axisDirection: metrics.axisDirection,
               maxScrollExtent: metrics.maxScrollExtent,


### PR DESCRIPTION
…arations

When I cloned the main branch and attempted to build the example with 'flutter run', I could not build as I was getting the error:

'The named parameter 'devicePixelRatio' is required, but there's no corresponding argument. Try adding the required argument.'