### PR TITLE
Fix/app bar theme type mis match

### DIFF
--- a/lib/src/floating_search_app_bar.dart
+++ b/lib/src/floating_search_app_bar.dart
@@ -632,7 +632,7 @@ class FloatingSearchAppBarState extends ImplicitlyAnimatedWidgetState<
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: Theme.of(context).appBarTheme.toolbarTextStyle ??
-                Theme.of(context).textTheme.headline6 ??
+                Theme.of(context).textTheme.titleSmall ??
                 const TextStyle(),
             child: input,
           );

--- a/lib/src/floating_search_app_bar.dart
+++ b/lib/src/floating_search_app_bar.dart
@@ -644,7 +644,7 @@ class FloatingSearchAppBarState extends ImplicitlyAnimatedWidgetState<
         final textStyle = hasQuery
             ? style.queryStyle ?? textTheme.titleMedium
             : style.hintStyle ??
-                textTheme.subtitle1?.copyWith(color: theme.hintColor);
+                textTheme.titleMedium?.copyWith(color: theme.hintColor);
 
         input = Text(
           hasQuery ? query : widget.hint ?? '',

--- a/lib/src/floating_search_app_bar.dart
+++ b/lib/src/floating_search_app_bar.dart
@@ -642,7 +642,7 @@ class FloatingSearchAppBarState extends ImplicitlyAnimatedWidgetState<
         final textTheme = theme.textTheme;
 
         final textStyle = hasQuery
-            ? style.queryStyle ?? textTheme.subtitle1
+            ? style.queryStyle ?? textTheme.titleMedium
             : style.hintStyle ??
                 textTheme.subtitle1?.copyWith(color: theme.hintColor);
 

--- a/lib/src/floating_search_bar_scroll_notifier.dart
+++ b/lib/src/floating_search_bar_scroll_notifier.dart
@@ -41,6 +41,7 @@ class FloatingSearchBarScrollNotifier extends StatelessWidget {
               maxScrollExtent: metrics.maxScrollExtent,
               minScrollExtent: metrics.minScrollExtent,
               viewportDimension: metrics.viewportDimension,
+              devicePixelRatio: metrics.devicePixelRatio
             );
           }
 


### PR DESCRIPTION
this fatal error occurred :

Error: A value of type 'AppBarThemeData' can't be assigned to a variable of type 'AppBarTheme'

So I had to change

final AppBarTheme appBar = theme.appBarTheme;

to 

final AppBarThemeData appBar = theme.appBarTheme;

in floating_search_app_bar.dart