### PR TITLE
Use theme data

### DIFF
--- a/lib/src/floating_search_app_bar.dart
+++ b/lib/src/floating_search_app_bar.dart
@@ -687,7 +687,7 @@ class FloatingSearchAppBarState extends ImplicitlyAnimatedWidgetState<
   @override
   FloatingSearchAppBarStyle get newValue {
     final ThemeData theme = Theme.of(context);
-    final AppBarTheme appBar = theme.appBarTheme;
+    final AppBarThemeData appBar = theme.appBarTheme;
     final TextDirection direction = Directionality.of(context);
 
     return FloatingSearchAppBarStyle(

--- a/lib/src/floating_search_bar_scroll_notifier.dart
+++ b/lib/src/floating_search_bar_scroll_notifier.dart
@@ -41,6 +41,7 @@ class FloatingSearchBarScrollNotifier extends StatelessWidget {
               maxScrollExtent: metrics.maxScrollExtent,
               minScrollExtent: metrics.minScrollExtent,
               viewportDimension: metrics.viewportDimension,
+              devicePixelRatio: metrics.devicePixelRatio
             );
           }
 


### PR DESCRIPTION
Error with Flutter 3.35.3:

../../../AppData/Local/Pub/Cache/hosted/pub.dev/material_floating_search_bar_2-0.5.0/lib/src/floating_search_app_bar.dart:690:38: Error: A value of type 'AppBarThemeData' can't be assigned to a variable of type 'AppBarTheme'.